### PR TITLE
Initialize health checks from class names

### DIFF
--- a/src/Utils/CheckList.php
+++ b/src/Utils/CheckList.php
@@ -7,5 +7,14 @@ use Vistik\Collections\TypedCollection;
 
 class CheckList extends TypedCollection
 {
+    public function __construct($checks) {
+        $cast = function ($check) {
+            if ($check instanceof HealthCheck) return $check;
+            if (is_string($check)) return new $check;
+            if (is_array($check)) return new $check[0](...array_slice($check, 1));
+        };
+        parent::__construct(array_map($cast, $checks));
+    }
+
     protected $type = HealthCheck::class;
 }

--- a/src/Utils/CheckList.php
+++ b/src/Utils/CheckList.php
@@ -7,12 +7,20 @@ use Vistik\Collections\TypedCollection;
 
 class CheckList extends TypedCollection
 {
-    public function __construct($checks) {
+    public function __construct($checks)
+    {
         $cast = function ($check) {
-            if ($check instanceof HealthCheck) return $check;
-            if (is_string($check)) return new $check;
-            if (is_array($check)) return new $check[0](...array_slice($check, 1));
+            if ($check instanceof HealthCheck) {
+                return $check;
+            }
+            if (is_string($check)) {
+                return new $check;
+            }
+            if (is_array($check)) {
+                return new $check[0](...array_slice($check, 1));
+            }
         };
+        
         parent::__construct(array_map($cast, $checks));
     }
 


### PR DESCRIPTION
Allows setting the health checks in the health.php as strings or arrays in the case we need to pass in a parameter.
This fixes the invalid config.php that is generated when we cache the configuration.

https://github.com/OveD-php/health-checks/issues/13